### PR TITLE
Fixed scalable icon MinSize for issue #106

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -54,8 +54,8 @@ Type=Fixed
 Size=64
 Context=Applications
 Type=Scalable
-MinSize=1
-MaxSize=256
+MinSize=16
+MaxSize=512
 
 [categories/16]
 Size=16
@@ -76,8 +76,8 @@ Type=Fixed
 Size=64
 Context=Categories
 Type=Scalable
-MinSize=1
-MaxSize=256
+MinSize=16
+MaxSize=512
 
 [devices/16]
 Size=16
@@ -108,8 +108,8 @@ Type=Fixed
 Size=48
 Context=MimeTypes
 Type=Scalable
-MinSize=1
-MaxSize=256
+MinSize=16
+MaxSize=512
 
 [places/16]
 Size=16
@@ -120,8 +120,8 @@ Type=Fixed
 Size=64
 Context=Places
 Type=Scalable
-MinSize=1
-MaxSize=256
+MinSize=16
+MaxSize=512
 
 [status/22]
 Size=22

--- a/index.theme
+++ b/index.theme
@@ -54,7 +54,7 @@ Type=Fixed
 Size=64
 Context=Applications
 Type=Scalable
-MinSize=64
+MinSize=1
 MaxSize=256
 
 [categories/16]
@@ -76,7 +76,7 @@ Type=Fixed
 Size=64
 Context=Categories
 Type=Scalable
-MinSize=64
+MinSize=1
 MaxSize=256
 
 [devices/16]
@@ -108,7 +108,7 @@ Type=Fixed
 Size=48
 Context=MimeTypes
 Type=Scalable
-MinSize=48
+MinSize=1
 MaxSize=256
 
 [places/16]
@@ -120,7 +120,7 @@ Type=Fixed
 Size=64
 Context=Places
 Type=Scalable
-MinSize=64
+MinSize=1
 MaxSize=256
 
 [status/22]


### PR DESCRIPTION
I set the MinSize for all scaleable icons to 1 to fix the icon size problem in Gnome. I am not sure if this has consequences for other platforms, but I generally found that most people recommended a MinSize of 1 for scaleable icons.

![screenshot from 2015-01-24 15 07 59](https://cloud.githubusercontent.com/assets/382041/5888844/e89481be-a3db-11e4-964b-9ad027fd8149.png)
