### PR TITLE
Added Google Chrome beta symlink so icon will display correctly.

### DIFF
--- a/apps/64/google-chrome-beta.svg
+++ b/apps/64/google-chrome-beta.svg
@@ -1,0 +1,1 @@
+google-chrome.svg


### PR DESCRIPTION
I noticed google-chrome-beta on Arch Linux was using the packaged icon rather than the theme icon. Symlink fixed that right up.